### PR TITLE
Code block tests

### DIFF
--- a/ctil.cpp
+++ b/ctil.cpp
@@ -78,13 +78,13 @@ void ctil::fencedCodeBlockUpdate(std::string &input) {
   size_t found = input.find(fencedCodeBlock);
   std::string lang = " class='language-html'";
   while (found != std::string::npos) {
-    size_t end = input.find(fencedCodeBlock, found + 1);
+    size_t end = input.find(fencedCodeBlock, found + 3);
     if (end != std::string::npos) {
       std::string blockToReplace = "<pre><code" + lang + ">" +
-                                   input.substr(found + 1, end - found - 1) +
+                                   input.substr(found + 3, end - found - 3) +
                                    "</code></pre>";
-      input.replace(found, end - found + 1, blockToReplace);
-      found = input.find(fencedCodeBlock, end + 1);
+      input.replace(found, end + 3, blockToReplace);
+      found = input.find(fencedCodeBlock, end + 3);
     } else
       break;
   }

--- a/test.cpp
+++ b/test.cpp
@@ -25,3 +25,10 @@ TEST(CtilTest, CodeBlockUpdateTest) {
   ctil.codeblockUpdate(test);
   EXPECT_EQ(test, "<code>This is a sentence.</code>");
 }
+
+TEST(CtilTest, FencedCodeBlockUpdateTestHTML) {
+  cdot::ctil ctil;
+  std::string test = "```This is a sentence.```";
+  ctil.fencedCodeBlockUpdate(test);
+  EXPECT_EQ(test, "<pre><code class='language-html'>This is a sentence.</code></pre>");
+}

--- a/test.cpp
+++ b/test.cpp
@@ -1,7 +1,7 @@
 #include "pch.h"
 #include "ctil.cpp"
 #include "ctil.h"
-using namespace cdot;
+
 TEST(CtilTest, TxtSuffixTrue) {
   cdot::ctil ctil;
   EXPECT_TRUE(ctil.has_txt_suffix("test.txt"));

--- a/test.cpp
+++ b/test.cpp
@@ -1,7 +1,7 @@
 #include "pch.h"
 #include "ctil.cpp"
 #include "ctil.h"
-
+using namespace cdot;
 TEST(CtilTest, TxtSuffixTrue) {
   cdot::ctil ctil;
   EXPECT_TRUE(ctil.has_txt_suffix("test.txt"));
@@ -17,4 +17,11 @@ TEST(CtilTest, HorizontalBreaksReplaced) {
   std::string test = "--- I like markdown!";
   ctil.horizontalBreakUpdate(test);
   EXPECT_EQ(test, "<hr /> I like markdown!");
+}
+
+TEST(CtilTest, CodeBlockUpdateTest) {
+  cdot::ctil ctil;
+  std::string test = "`This is a sentence.`";
+  ctil.codeblockUpdate(test);
+  EXPECT_EQ(test, "<code>This is a sentence.</code>");
 }


### PR DESCRIPTION
Added the following tests to `CtilTest` Test Suite inside `test.cpp`:
- **CodeBlockUpdateTest** - tests `ctil::codeblockUpdate()`
- **FencedCodeBlockUpdateTestHTML** - tests `ctil::fencedCodeBlockUpdate()` with HTML as default language in code block

Debugged `ctil::fencedCodeBlockUpdate()` as it failed FencedCodeBlockUpdateTestHTML