### PR TITLE
added unit tests for ctil::ends_with

### DIFF
--- a/test.cpp
+++ b/test.cpp
@@ -32,3 +32,15 @@ TEST(CtilTest, FencedCodeBlockUpdateTestHTML) {
   ctil.fencedCodeBlockUpdate(test);
   EXPECT_EQ(test, "<pre><code class='language-html'>This is a sentence.</code></pre>");
 }
+
+TEST(CtilTest, EndsWithTrue) {
+  cdot::ctil ctil;
+  std::string test = "sample_file.txt";
+  EXPECT_TRUE(ctil.ends_with(test, ".txt"));
+}
+
+TEST(CtilTest, EndsWithFalse) {
+  cdot::ctil ctil;
+  std::string test = "sample_file.txt";
+  EXPECT_FALSE(ctil.ends_with(test, ".html"));
+}


### PR DESCRIPTION
Closes #13

Added two unit tests to test when `ctil::ends_with()` returns `true` and when it returns `false`

![image](https://github.com/rjwignar/ctil/assets/98062538/a026c4fc-2772-49ee-bf0d-899191af4ff4)
